### PR TITLE
Pin nginx:alpine to nginx:1.29-alpine for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.29-alpine
 LABEL org.opencontainers.image.authors="nat@natwelch.com"
 
 EXPOSE 8080


### PR DESCRIPTION
## Problem

`FROM nginx:alpine` (without a version tag) is a non-reproducible base image. Two builds at different times may pull different nginx versions, which can silently introduce CVEs or breaking changes.

## Fix

Pin to `nginx:1.29-alpine` (current stable), matching the pattern already used in `locative.garden`.

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | `FROM nginx:alpine` unpinned | **Fixed (this PR)** |
| Static site | Single `index.html` with pinned nginx config | No action needed |
