### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:1.29-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/icco/subalpinedrift
-LABEL org.opencontainers.image.description="ghcr.io/icco/subalpinedrift container image"
+LABEL org.opencontainers.image.description="Landing page for Sub Alpine Drift, the electronic music project by Nat Welch (subalpinedrift.com); a static site served via nginx."
 LABEL org.opencontainers.image.authors="nat@natwelch.com"
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM nginx:1.29-alpine
+
+LABEL org.opencontainers.image.source=https://github.com/icco/subalpinedrift
+LABEL org.opencontainers.image.description="ghcr.io/icco/subalpinedrift container image"
 LABEL org.opencontainers.image.authors="nat@natwelch.com"
 
 EXPOSE 8080


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)