### PR TITLE
fix: emit nginx access logs as JSON

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,19 @@
+log_format json_combined escape=json
+'{'
+  '"time":"$time_iso8601",'
+  '"remote_addr":"$remote_addr",'
+  '"method":"$request_method",'
+  '"path":"$request_uri",'
+  '"status":$status,'
+  '"size":$body_bytes_sent,'
+  '"referer":"$http_referer",'
+  '"user_agent":"$http_user_agent",'
+  '"request_time":$request_time'
+'}';
+
 server {
   listen 8080;
+  access_log /var/log/nginx/access.log json_combined;
 
   # Reporting endpoints
   add_header Reporting-Endpoints 'default="https://reportd.natwelch.com/reporting/subalpinedrift"' always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,7 +13,7 @@ log_format json_combined escape=json
 
 server {
   listen 8080;
-  access_log /var/log/nginx/access.log json_combined;
+  access_log /dev/stdout json_combined;
 
   # Reporting endpoints
   add_header Reporting-Endpoints 'default="https://reportd.natwelch.com/reporting/subalpinedrift"' always;


### PR DESCRIPTION
Switch nginx access log to JSON so Loki can parse method/path/status as fields.

## Test plan
- [ ] After deploy, `| json` parses the log line in Grafana.